### PR TITLE
Permit minus signs at either end of the raw and endraw tags

### DIFF
--- a/Syntaxes/Jinja2.tmLanguage
+++ b/Syntaxes/Jinja2.tmLanguage
@@ -16,7 +16,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>({%)\s*(raw)\s*(%})</string>
+			<string>({%)-?\s*(raw)\s*-?(%})</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -36,7 +36,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>({%)\s*(endraw)\s*(%})</string>
+			<string>({%)-?\s*(endraw)\s*-?(%})</string>
 			<key>name</key>
 			<string>comment.block.jinja2.raw</string>
 		</dict>


### PR DESCRIPTION
Syntax highlighting for the `raw` and `endraw` tags did not work if there was a minus sign on either end of the tag.

Here is the relevant [documentation](https://jinja.palletsprojects.com/en/2.11.x/templates/#escaping).